### PR TITLE
fix(ci): add version comments to GitHub Actions for Renovate support

### DIFF
--- a/.github/workflows/reusable_release_tag.yml
+++ b/.github/workflows/reusable_release_tag.yml
@@ -32,17 +32,17 @@ jobs:
       version: ${{ steps.semver.outputs.version }}
       version_tag: ${{ steps.semver.outputs.version_tag }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Bump semver
         id: semver
-        uses: paulhatch/semantic-version@9f72830310d5ed81233b641ee59253644cd8a8fc
+        uses: paulhatch/semantic-version@9f72830310d5ed81233b641ee59253644cd8a8fc # v6.0.2
         with:
           tag_prefix: ${{ inputs.tag_prefix }}
           namespace: ${{ inputs.tag_suffix }}
       - name: Create and push semver tag
-        uses: anothrNick/github-tag-action@4ed44965e0db8dab2b466a16da04aec3cc312fd8
+        uses: anothrNick/github-tag-action@4ed44965e0db8dab2b466a16da04aec3cc312fd8 # v1.73.0
         env:
           GITHUB_TOKEN: ${{ secrets.custom_github_token || secrets.GITHUB_TOKEN }}
           CUSTOM_TAG: ${{ steps.semver.outputs.version_tag }}

--- a/.github/workflows/reusable_renovate_checks.yml
+++ b/.github/workflows/reusable_renovate_checks.yml
@@ -9,6 +9,6 @@ jobs:
       image: renovate/renovate:latest
       options: --user root # root is needed for checkout to work
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Validate Renovate config
         run: renovate-config-validator --strict

--- a/.github/workflows/reusable_tf_checks.yml
+++ b/.github/workflows/reusable_tf_checks.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ contains(fromJson(inputs.checks_enabled), 'tf_fmt') }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup terraform
-        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
       - name: Run terraform fmt
         run: terraform fmt ${{ inputs.tf_fmt_args }} ${{ inputs.working_directory }}
 
@@ -42,9 +42,9 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ contains(fromJson(inputs.checks_enabled), 'trivy_config_scan') }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run trivy config scan
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           github-pat: ${{ secrets.GITHUB_TOKEN }}
           scan-type: config
@@ -58,13 +58,13 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ contains(fromJson(inputs.checks_enabled), 'tflint') }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         name: Cache plugin dir
         with:
           path: ~/.tflint.d/plugins
           key: tflint-${{ hashFiles('.tflint.hcl') }}
-      - uses: terraform-linters/setup-tflint@b480b8fcdaa6f2c577f8e4fa799e89e756bb7c93
+      - uses: terraform-linters/setup-tflint@b480b8fcdaa6f2c577f8e4fa799e89e756bb7c93 # v6.2.2
         name: Setup TFLint
         with:
           tflint_version: latest
@@ -78,11 +78,11 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ contains(fromJson(inputs.checks_enabled), 'terraform_docs') }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Validate terraform docs are present and valid
-        uses: terraform-docs/gh-actions@6de6da0cefcc6b4b7a5cbea4d79d97060733093c
+        uses: terraform-docs/gh-actions@6de6da0cefcc6b4b7a5cbea4d79d97060733093c # v1.4.1
         with:
           find-dir: ${{ inputs.working_directory }}
           fail-on-diff: true


### PR DESCRIPTION
# Description
Adds version comments to all third-party GitHub Actions references to enable Renovate to detect and suggest updates for tagged releases.
